### PR TITLE
splitting node and process

### DIFF
--- a/doc/tutorial.rst
+++ b/doc/tutorial.rst
@@ -46,18 +46,79 @@ Back into the same python intrepreter::
     >>> question
     <pyzmp.service.Service object at 0x7fc1607215d0>
     >>> question.call()
-    Traceback (most recent call last):
     42
     >>>
 
 So here we have a very basic example of a communication between different processes through ZMQ.
 
-TODO : example using delegation
+Simple RPC client / server example with context management
+----------------------------------------------------------
+
+A pyzmp Node is also a context manager (since there is a resource to initialize and cleanup : the process),
+which means you can shorten your code, and prevent leaving useless processes behind. The previous example can be rewritten ::
+
+    Python 2.7.12 (default, Dec  4 2017, 14:50:18)
+    [GCC 5.4.0 20160609] on linux2
+    Type "help", "copyright", "credits" or "license" for more information.
+    >>> import pyzmp
+    WARNING:root:ZMQ : Protobuf message implementation not found. Using pickle based protocol
+    >>> class ServerNode(pyzmp.Node):
+    ...     def __init__(self, name):
+    ...             super(ServerNode, self).__init__(name)
+    ...             self.the_answer = 42
+    ...             self.provides(self.question)
+    ...     def question(self):
+    ...             return self.the_answer
+    ...
+    >>> with ServerNode("srv") as srv:
+    ...     question = pyzmp.discover("question")
+    ...     question.call()
+    ...
+    [srv] Proc started as [5393]
+    42
+    Shutdown initiated
+    >>>
+
+Here the srv process was started when entering the "with:" block, and was terminated when exiting it.
+
+Simple RPC client / server example with delegation
+--------------------------------------------------
+Often having hierarchy will make your code more complex, and difficult to evolve when requirements change.
+So you can also use pyzmp.Node as a delegate.
+
+
+Disclaimer : currently BROKEN : see https://github.com/asmodehn/pyzmp/issues/36
+You should implement your own context manager, which is what you want to do most of the time to control initialization anyway::
+
+    >>> class ServerNode(object):
+    ...     def __init__(self, name):
+    ...         self.node = pyzmp.Node(name)
+    ...         self.the_answer = 42
+    ...         self.node.provides(self.question)
+    ...     def question(self):
+    ...         return self.the_answer
+    ...     def __enter__(self):
+    ...         return self.node.__enter__()
+    ...     def __exit__(self ,type, value, traceback):
+    ...         return self.node.__exit__(type, value, traceback)
+    ...
+    >>> with ServerNode("srv") as srv:
+    ...     question = pyzmp.discover("question")
+    ...     question.call()
+    ...
+    [srv] Proc started as [5973]
+    Shutdown initiated
+
+
+
+
+Context managers are used only in the child process, but enter() and exit() calls are in order which provide deterministic behavior,
+by contrast to multiprocess communication which is by default indeterministic.
 
 A current limitation however is that discover currently works out of the box only from the same python interpreter.
 As a result we have to rely on a process manager running in the same interpreter.
 
-A later version will provide an API to make this, between two different interpreters, trivial, so that process management can be done somewhere else.
+A later version will provide an API to make this simple, even between two different interpreters, so that process management can be done somewhere else.
 
 
 

--- a/pyzmp/__init__.py
+++ b/pyzmp/__init__.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 
 from .exceptions import UnknownServiceException, UnknownRequestTypeException, UnknownResponseTypeException
 from .master import manager
+from .coprocess import CoProcess
 from .node import Node, current_node
 from .service import Service, services, discover, ServiceCallTimeout
 
@@ -38,6 +39,6 @@ from .helpers import process_watcher_cm
 
 __all__ = [
     'UnknownServiceException', 'UnknownRequestTypeException', 'UnknownResponseTypeException',
-    'Node', 'nodes', 'current_node',
+    'Node', 'current_node',
     'Service', 'services', 'discover', 'ServiceCallTimeout'
 ]

--- a/pyzmp/coprocess.py
+++ b/pyzmp/coprocess.py
@@ -176,10 +176,10 @@ class CoProcess(object):
     # TODO : decorator to easily mix functional(via param) and inheritance(OO) API styles
     # See type classes, traits, etc.
     @contextlib.contextmanager
-    def __chained_ctx(self):
+    def __chained_ctx(self, *args, **kwargs):
         # CAREFUL with timing constraints
         # TODO check with python 3.1 and list of CMs...
-        with self.child_context() as cm:
+        with self.child_context(*args, **kwargs) as cm:
 
             ctxt = tuple()
 
@@ -187,7 +187,7 @@ class CoProcess(object):
                 ctxt = ctxt + maybe_tuple(cm)
 
             if self._user_ctx:
-                with self._user_ctx() as ucm:
+                with self._user_ctx(*args, **kwargs) as ucm:
                     if ucm is not None:
                         ctxt = ctxt + maybe_tuple(ucm)
                         # skipping Empty (None) Context
@@ -204,7 +204,7 @@ class CoProcess(object):
                     yield
 
     @contextlib.contextmanager
-    def child_context(self):
+    def child_context(self, *args, **kwargs):
         yield
 
     def has_started(self):
@@ -445,7 +445,7 @@ class CoProcess(object):
 
         print('[{proc}] Proc started as [{pid}]'.format(proc=self.name, pid=self.ident))
 
-        with self.context_manager() as cm:
+        with self.context_manager(*args, **kwargs) as cm:
             if cm:
                 cmargs = maybe_tuple(cm)
                 # prepending context manager, to be able to access it from target

--- a/pyzmp/coprocess.py
+++ b/pyzmp/coprocess.py
@@ -128,6 +128,7 @@ class CoProcess(object):
 
     # TODO : allow just passing target to be able to make a Node from a simple function, and also via decorator...
     def __init__(self, name=None, context_manager=None, target=None, args=None, kwargs=None):
+        # TODO : types hint to check context signature would avoid concurrency issues
         """
         Initializes a ZMP Node (Restartable Python Process communicating via ZMQ)
         :param name: Name of the node

--- a/pyzmp/coprocess.py
+++ b/pyzmp/coprocess.py
@@ -1,0 +1,463 @@
+# -*- coding: utf-8 -*-
+# This python package is implementing a very simple multiprocess framework
+# The point of it is to be able to fully tests the multiprocess behavior,
+#     in pure python, without having to run a ROS system.
+from __future__ import absolute_import
+from __future__ import print_function
+
+import os
+import sys
+import tempfile
+import multiprocessing, multiprocessing.reduction
+import types
+import uuid
+
+import errno
+import zmq
+import socket
+import logging
+import pickle
+import contextlib
+#import dill as pickle
+
+# allowing pickling of exceptions to transfer it
+from collections import namedtuple
+
+import time
+
+try:
+    from tblib.decorators import Traceback
+    # TODO : potential candidates for pickle + tblib replacement for easier serialization
+    # TODO : - https://github.com/uqfoundation/dill
+    # TODO : - OR https://github.com/cloudpipe/cloudpickle
+    # TODO : - OR https://github.com/irmen/Serpent ?
+    # TODO : - OR https://github.com/esnme/ultrajson ?
+    # TODO : - OR something else ?
+except ImportError:
+    Traceback = None
+
+try:
+    import setproctitle
+except ImportError:
+    setproctitle = None
+
+### IMPORTANT : COMPOSITION -> A SET OF NODE SHOULD ALSO 'BE' A NODE ###
+### IMPORTANT : IDENTITY
+### Category Theory https://en.wikipedia.org/wiki/Category_theory
+
+### Data Flow with topic :
+#
+# object : message
+# arrow : topic_listener
+# binary op - associativity : listener l1, l2, l3 <= (l1 . l2) .l3 == l1. (l2. l3)
+# binary op - identity : noop on listener => msg transfer as is
+# -> Expressed in programming language (functional programming follows category theory) :
+# msg3 = topic2_listener(topic1_listener(msg1))
+
+# -> Expressed in graph :
+# msg3 <--topic2_listener-- msg2 <--topic1_listener-- msg1
+
+### RPC with services :
+#
+# object : (req, resp)
+# arrow : service_call
+# binary op - associativity : service s1, s2, s3 <= (s1 . s2) .s3 == s1. (s2. s3)
+# binary op - identity : noop on service => (req, resp) transfer as is ( two ways comm )
+# -> Expressed in programming language (functional programming follows category theory) :
+#  (req3, resp3) = service2_call(service1_call((req1, resp1)))
+
+# -> Expressed in graph :
+# msg1 --service1_call--> msg2 --service2_call--> msg3
+
+###### higher level for execution graph to be represented by a category ######
+
+# TODO : CAREFUL topic is probably not a complete concept in itself
+# => often we need to get back to pub / sub connections rather than dealing with "topics"
+# We need the reverse flow of "service call" which is a distributed generalisation of function call
+# We need the distributed generalisation of the callback function ( async calls and futures )
+
+### Service is a first class citizen. node is abstracted in that perspective : implementation requires some discovery mechanism.
+# object : service
+# arrow : call
+# binary op - associativity : call c1, c2, c3 <= (c1 . c2) .c3 == c1 . (c2 . c3)
+# binary op - identity : ??? TODO
+# -> Expressed in programming language (functional programming follows category theory) :
+#  svc1 = lambda x: return ( lambda y: return svc3(y) )( x )  <= currying/partial => svc1 = lambda x, y : return svc23(x,y)
+
+# -> Expressed in graph :
+# svc1 --call--> svc2 --call--> svc3
+
+### Node is a first class citizen
+# object : node
+# arrow : topic_listener / callback
+# binary op - associativity : callback cb1. cb2. cb3 <= (cb1 . cb2) . cb3 == cb1 . (cb2 . cb3)
+# binary op - identity : ??? TODO
+# -> Expressed in programming language (functional programming follows category theory) :
+#  node1.cb = lambda x: return ( lambda y: return node3.cb(y) )(x) <= currying/partial => node1.cb = lambda x, y : return node23(x,y)
+
+# -> Expressed in graph :
+# node3 <--topic_cb-- node2 <--topic_cb-- node1
+
+from .master import manager
+from .exceptions import UnknownServiceException, UnknownRequestTypeException
+from .message import ServiceRequest, ServiceRequest_dictparse, ServiceResponse, ServiceException
+from .service import service_provider_cm
+#from .service import RequestMsg, ResponseMsg, ErrorMsg  # only to access message types
+
+
+
+
+
+def maybe_tuple(a):
+    return a if isinstance(a, tuple) else (a,)
+
+
+# CAREFUL here : multiprocessing documentation specifies that a process object can be started only once...
+class CoProcess(object):
+    """
+    A Collaborative Process (co- as in coroutines)
+    Guarantees (process-level) Atomicity and (process-level) Isolation (as in ACID acronym)
+    Interruption are signals only, following POSIX standard (for now...)
+    Note that it can only keep guarantees that executed code does not violate
+    Therefore using async coroutines inside, and implement pure functional features from outside perspective, is the preferred style.
+    """
+    # TODO : UNTANGLE this with asyncio.
+    # We have here and event loop inside a process, but it should be more modular...
+    # maybe also add a distributed constant scheduler (like erlang VM : each loop gets equal amount of cycles)...
+    EndPoint = namedtuple("EndPoint", "self func")
+
+    # TODO : allow just passing target to be able to make a Node from a simple function, and also via decorator...
+    def __init__(self, name=None, context_manager=None, target=None, args=None, kwargs=None):
+        """
+        Initializes a ZMP Node (Restartable Python Process communicating via ZMQ)
+        :param name: Name of the node
+        :param context_manager: a context_manager to be used with run (in a with statement)
+        :return:
+        """
+        # TODO check name unicity
+        # using process as delegate
+        self._pargs = {
+            'name': name or str(uuid.uuid4()),
+            'args': args or (),
+            'kwargs': kwargs or {},
+            'target': self.run,  # Careful : our run() is not the same as the one for Process
+        }
+        # Careful : our own target is not the same as the one for Process
+        self._target = target or self.task
+
+        #: the actual process instance. lazy creation on start() call only.
+        self._process = None
+
+        #: whether or not the node name should be set as the actual process title
+        #: replacing the string duplicated from the python interpreter run
+        self.new_title = True
+
+        self._user_ctx = context_manager
+        self.context_manager = self.__chained_ctx  # TODO: extend to list if possible ( available for python >3.1 only )
+
+        self.exit = multiprocessing.Event()
+        self.started = multiprocessing.Event()
+
+        self.tmpdir = tempfile.mkdtemp(prefix='zmp-' + self.name + '-')
+
+    def __enter__(self):
+        # __enter__ is called only if we pass this instance to with statement ( after __init__ )
+        # start only if needed (so that we can hook up a context manager to a running node) :
+        if not self.is_alive():
+            self.start()
+            # Note : start() will spawn the child process, which will enter it s own child_context
+            # in effect actually chaining this context and its own internal context before retuning
+        return self
+
+    def __exit__(self, exception_type, exception_value, traceback):
+        # make sure we cleanup when we exit
+        self.shutdown()
+
+    # TODO : decorator to easily mix functional(via param) and inheritance(OO) API styles
+    # See type classes, traits, etc.
+    @contextlib.contextmanager
+    def __chained_ctx(self):
+        # CAREFUL with timing constraints
+        # TODO check with python 3.1 and list of CMs...
+        with self.child_context() as cm:
+
+            ctxt = tuple()
+
+            if cm is not None:
+                ctxt = ctxt + maybe_tuple(cm)
+
+            if self._user_ctx:
+                with self._user_ctx() as ucm:
+                    if ucm is not None:
+                        ctxt = ctxt + maybe_tuple(ucm)
+                        # skipping Empty (None) Context
+
+                    if ctxt:
+                        yield ctxt
+                    else:
+                        yield
+
+            else:
+                if ctxt:
+                    yield ctxt
+                else:
+                    yield
+
+    @contextlib.contextmanager
+    def child_context(self):
+        yield
+
+    def has_started(self):
+        """
+        :return: True if the node has started (update() might not have been called yet). Might still be alive, or not...
+        """
+        return self.started.is_set()
+
+    ### Process API delegation ###
+    def is_alive(self):
+        if self and self._process:
+            return self._process.is_alive()
+
+    def join(self, timeout=None):
+        if not self._process:
+            # blocking on started event before blocking on join
+            self.started.wait(timeout=timeout)
+        return self._process.join(timeout=timeout)
+
+    @property
+    def name(self):
+        if self and self._process:
+            return self._process.name
+        else:
+            return self._pargs.get('name', "ZMPNode")
+
+    @name.setter
+    def name(self, name):
+        if self and self._process:
+            self._process.name = name
+            # only reset the name arg if it was accepted by the setter
+            self._pargs['name']= self._process.name
+        else:
+            # TODO : maybe we should be a bit more strict here ?
+            self._pargs['name']= name
+
+    @property
+    def daemon(self):
+        """
+        Return whether process is a daemon
+        :return:
+        """
+        if self._process:
+            return self._process.daemon
+        else:
+            return self._pargs.get('daemonic', False)
+
+    @daemon.setter
+    def daemon(self, daemonic):
+        """
+        Set whether process is a daemon
+        :param daemonic:
+        :return:
+        """
+        if self._process:
+            self._process.daemonic = daemonic
+        else:
+            self._pargs['daemonic'] = daemonic
+
+    @property
+    def authkey(self):
+        return self._process.authkey
+
+    @authkey.setter
+    def authkey(self, authkey):
+        """
+        Set authorization key of process
+        """
+        self._process.authkey = authkey
+
+    @property
+    def exitcode(self):
+        """
+        Return exit code of process or `None` if it has yet to stop
+        """
+        if self._process:
+            return self._process.exitcode
+        else:
+            return None
+
+    @property
+    def ident(self):
+        """
+        Return identifier (PID) of process or `None` if it has yet to start
+        """
+        if self._process:
+            return self._process.ident
+        else:
+            return None
+
+    def __repr__(self):
+        # TODO : improve this
+        return self._process.__repr__()
+
+    def start(self, timeout=None):
+        """
+        Start child process
+        :param timeout: the maximum time to wait for child process to report it has actually started.
+        None waits until the context manager has been entered, but update might not have been called yet.
+        """
+
+        # we lazily create our process delegate (with same arguments)
+        if self.daemon:
+            daemonic = True
+        else:
+            daemonic = False
+
+        pargs = self._pargs.copy()
+        pargs.pop('daemonic', None)
+
+        self._process = multiprocessing.Process(**pargs)
+
+        self._process.daemon = daemonic
+
+        if self.is_alive():
+            # if already started, we shutdown and join before restarting
+            # not timeout will bock here (default join behavior).
+            # otherwise we simply use the same timeout.
+            self.shutdown(join=True, timeout=timeout)  # TODO : only restart if no error (check exitcode)
+            self.start(timeout=timeout)  # recursive to try again if needed
+        else:
+            self._process.start()
+
+        # timeout None means we want to wait and ensure it has started
+        # deterministic behavior, like is_alive() from multiprocess.Process is always true after start()
+        if self.started.wait(timeout=timeout):  # blocks until we know true or false
+
+
+            return True
+            # return self._svc_address  # returning the zmp url as a way to connect to the node
+            # CAREFUL : doesnt make sense if this node only run a one-time task...
+        # TODO: futures and ThreadPoolExecutor (so we dont need to manage the pool ourselves)
+        else:
+            return False
+
+    # TODO : Implement a way to redirect stdout/stderr, or even forward to parent ?
+    # cf http://ryanjoneil.github.io/posts/2014-02-14-capturing-stdout-in-a-python-child-process.html
+
+    def terminate(self):
+        """Forcefully terminates the underlying process (using SIGTERM)"""
+        return self._process.terminate()
+        # TODO : maybe redirect to shutdown here to avoid child process leaks ?
+
+
+    # TODO : shortcut to discover/build only services provided by this node ?
+
+
+    def shutdown(self, join=True, timeout=None):
+        """
+        Clean shutdown of the node.
+        :param join: optionally wait for the process to end (default : True)
+        :return: None
+        """
+        if self.is_alive():  # check if process started
+            print("Shutdown initiated")
+            self.exit.set()
+            if join:
+                self.join(timeout=timeout)
+                # TODO : timeout before forcing terminate (SIGTERM)
+
+        exitcode = self._process.exitcode if self._process else None  # we return None if the process was never started
+        return exitcode
+
+    def task(self, *args, **kwargs):
+        """Child classes must define this method, that will be executed in a separate process,
+        giving *some* Atomicity and Isolation guarantees (see ACID and BASE acronym for background on this)"""
+        return  # careful : no side effects (exceptions or logs) by default !
+
+    def eventloop(self, *args, **kwargs):
+        """
+        Hand crafted event loop, with only one event possible : exit
+        More events ( and signals ) can be added later, after converting to asyncio.
+        """
+
+        # Setting status
+        status = None
+
+        # Starting the clock
+        start = time.time()
+
+        first_loop = True
+        # loop running target, maybe more than once
+        while not self.exit.is_set():
+
+            if first_loop:
+                first_loop = False
+                # signalling startup only the first time, just after having check for exit request.
+                # We need to return control before starting, but after entering context...
+                self.started.set()
+                # TODO : check if better outside of loop maybe ??
+                # It will change semantics, but might be more intuitive...
+
+            # time is ticking
+            # TODO : move this out of here. this class should require only generic interface to any method.
+            now = time.time()
+            timedelta = now - start
+            start = now
+
+            # replacing the original Process.run() call, passing arguments to our target
+            if self._target:
+                # bwcompat
+                kwargs['timedelta'] = timedelta
+
+                # TODO : use return code to determine when/how we need to run this the next time...
+                # Also we need to keep the exit status to be able to call external process as an update...
+
+                logging.debug(
+                    "[{self.name}] calling {self._target.__name__} with args {args} and kwargs {kwargs}...".format(
+                        **locals()))
+                status = self._target(*args, **kwargs)
+
+            if status is not None:
+                break
+
+        if self.started.is_set() and status is None and self.exit.is_set():
+            # in the not so special case where we started, we didnt get exit code and we exited,
+            # this is expected as a normal result and we set an exitcode here of 0
+            # As 0 is the conventional success for unix process successful run
+            status = 0
+
+        return status
+
+    def run(self, *args, **kwargs):
+        """
+        The Node main method, running in a child process (similar to Process.run() but also accepts args)
+        A children class can override this method, but it needs to call super().run(*args, **kwargs)
+        for the node to start properly and call update() as expected.
+        :param args: arguments to pass to update()
+        :param kwargs: keyword arguments to pass to update()
+        :return: last exitcode returned by update()
+        """
+        # TODO : make use of the arguments ? since run is now the target for Process...
+
+        exitstatus = None  # keeping the semantic of multiprocessing.Process : running process has None
+
+        if setproctitle and self.new_title:
+            setproctitle.setproctitle("{0}".format(self.name))
+
+        print('[{proc}] Proc started as [{pid}]'.format(proc=self.name, pid=self.ident))
+
+        with self.context_manager() as cm:
+            if cm:
+                cmargs = maybe_tuple(cm)
+                # prepending context manager, to be able to access it from target
+                args = cmargs + args
+
+            exitstatus = self.eventloop(*args, **kwargs)
+
+            logging.debug("[{self.name}] Proc exited.".format(**locals()))
+            return exitstatus  # returning last exit status from the update function
+
+        # all context manager is destroyed properly here
+
+
+
+

--- a/pyzmp/node.py
+++ b/pyzmp/node.py
@@ -99,6 +99,7 @@ except ImportError:
 # node3 <--topic_cb-- node2 <--topic_cb-- node1
 
 from .master import manager
+from .coprocess import CoProcess
 from .exceptions import UnknownServiceException, UnknownRequestTypeException
 from .message import ServiceRequest, ServiceRequest_dictparse, ServiceResponse, ServiceException
 from .service import service_provider_cm
@@ -111,9 +112,6 @@ nodes_lock = manager.Lock()
 nodes = manager.dict()
 
 
-@contextlib.contextmanager
-def dummy_cm():
-    yield None
 
 
 @contextlib.contextmanager
@@ -133,12 +131,12 @@ def node_cm(node_name, svc_address):
 
 # TODO : Nodelet ( thread, with fast intraprocess zmq comm - entity system design /vs/threadpool ?)
 # CAREFUL here : multiprocessing documentation specifies that a process object can be started only once...
-class Node(object):
+class Node(CoProcess):
 
     EndPoint = namedtuple("EndPoint", "self func")
 
     # TODO : allow just passing target to be able to make a Node from a simple function, and also via decorator...
-    def __init__(self, name=None, socket_bind=None, context_manager=None, target=None, args=None, kwargs=None):
+    def __init__(self, name=None, socket_bind=None, context_manager=None, loop_target=None, args=None, kwargs=None):
         """
         Initializes a ZMP Node (Restartable Python Process communicating via ZMQ)
         :param name: Name of the node
@@ -146,135 +144,28 @@ class Node(object):
         :param context_manager: a context_manager to be used with run (in a with statement)
         :return:
         """
-        # TODO check name unicity
-        # using process as delegate
-        self._pargs = {
-            'name': name or str(uuid.uuid4()),
-            'args': args or (),
-            'kwargs': kwargs or {},
-            'target': self.run,  # Careful : our run() is not the same as the one for Process
-        }
-        # Careful : our own target is not the same as the one for Process
-        self._target = target or self.update  # we expect the user to overload update in child class.
 
-        #: the actual process instance. lazy creation on start() call only.
-        self._process = None
+        @contextlib.contextmanager
+        def node_ctx_mgr():
+            with self.node_ctx() as ndcxt:
+                if context_manager:
+                    with context_manager as cm:
+                        yield ndcxt, cm
+                else:
+                    yield ndcxt
 
-        #: whether or not the node name should be set as the actual process title
-        #: replacing the string duplicated from the python interpreter run
-        self.new_title = True
+        super(Node, self).__init__(name=name, context_manager=node_ctx_mgr, target=self.receive_reply, args=args, kwargs=kwargs)
 
-        self.context_manager = context_manager or dummy_cm  # TODO: extend to list if possible ( available for python >3.1 only )
-        self.exit = multiprocessing.Event()
-        self.started = multiprocessing.Event()
+        self._loop_target = loop_target or self.update
+
         self.listeners = {}
         self._providers = {}
+
+        # TODO : proc or node ?
         self.tmpdir = tempfile.mkdtemp(prefix='zmp-' + self.name + '-')
         # if no socket is specified the services of this node will be available only through IPC
         self._svc_address = socket_bind if socket_bind else 'ipc://' + self.tmpdir + '/services.pipe'
 
-    def __enter__(self):
-        # __enter__ is called only if we pass this instance to with statement ( after __init__ )
-        # start only if needed (so that we can hook up a context manager to a running node) :
-        if not self.is_alive():
-            self.start()
-        return self
-
-    def __exit__(self, exception_type, exception_value, traceback):
-        # make sure we cleanup when we exit
-        self.shutdown()
-
-    def has_started(self):
-        """
-        :return: True if the node has started (update() might not have been called yet). Might still be alive, or not...
-        """
-        return self.started.is_set()
-
-    ### Process API delegation ###
-    def is_alive(self):
-        if self and self._process:
-            return self._process.is_alive()
-
-    def join(self, timeout=None):
-        if not self._process:
-            # blocking on started event before blocking on join
-            self.started.wait(timeout=timeout)
-        return self._process.join(timeout=timeout)
-
-    @property
-    def name(self):
-        if self and self._process:
-            return self._process.name
-        else:
-            return self._pargs.get('name', "ZMPNode")
-
-    @name.setter
-    def name(self, name):
-        if self and self._process:
-            self._process.name = name
-            # only reset the name arg if it was accepted by the setter
-            self._pargs.set('name', self._process.name)
-        else:
-            # TODO : maybe we should be a bit more strict here ?
-            self._pargs.set('name', name)
-
-    @property
-    def daemon(self):
-        """
-        Return whether process is a daemon
-        :return:
-        """
-        if self._process:
-            return self._process.daemon
-        else:
-            return self._pargs.get('daemonic', False)
-
-    @daemon.setter
-    def daemon(self, daemonic):
-        """
-        Set whether process is a daemon
-        :param daemonic:
-        :return:
-        """
-        if self._process:
-            self._process.daemonic = daemonic
-        else:
-            self._pargs['daemonic'] = daemonic
-
-    @property
-    def authkey(self):
-        return self._process.authkey
-
-    @authkey.setter
-    def authkey(self, authkey):
-        """
-        Set authorization key of process
-        """
-        self._process.authkey = authkey
-
-    @property
-    def exitcode(self):
-        """
-        Return exit code of process or `None` if it has yet to stop
-        """
-        if self._process:
-            return self._process.exitcode
-        else:
-            return None
-
-    @property
-    def ident(self):
-        """
-        Return identifier (PID) of process or `None` if it has yet to start
-        """
-        if self._process:
-            return self._process.ident
-        else:
-            return None
-
-    def __repr__(self):
-        # TODO : improve this
-        return self._process.__repr__()
 
     def start(self, timeout=None):
         """
@@ -308,22 +199,12 @@ class Node(object):
         # timeout None means we want to wait and ensure it has started
         # deterministic behavior, like is_alive() from multiprocess.Process is always true after start()
         if self.started.wait(timeout=timeout):  # blocks until we know true or false
+            # TODO : return something produced in the context manager passed
             return self._svc_address  # returning the zmp url as a way to connect to the node
             # CAREFUL : doesnt make sense if this node only run a one-time task...
         # TODO: futures and ThreadPoolExecutor (so we dont need to manage the pool ourselves)
         else:
             return False
-
-    # TODO : Implement a way to redirect stdout/stderr, or even forward to parent ?
-    # cf http://ryanjoneil.github.io/posts/2014-02-14-capturing-stdout-in-a-python-child-process.html
-
-    def terminate(self):
-        """Forcefully terminates the underlying process (using SIGTERM)"""
-        return self._process.terminate()
-        # TODO : maybe redirect to shutdown here to avoid child process leaks ?
-
-    ### Node specific API ###
-    # TODO : find a way to separate process management and service provider API
 
     def provides(self, svc_callback, service_name=None):
         service_name = service_name or svc_callback.__name__
@@ -352,6 +233,54 @@ class Node(object):
         # TODO : Check which way is better (can also be used to run external process, other functions, like Process)
         return None  # we keep looping by default (need to deal with services here...)
 
+    def receive_reply(self, poller, svc_skt, *args, **kwargs):
+        # blocking. messages are received ASAP. timeout only determine update/shutdown speed.
+        socks = dict(poller.poll(timeout=100))
+        if svc_skt in socks and socks[svc_skt] == zmq.POLLIN:
+            req = None
+            try:
+                req_unparsed = svc_skt.recv()
+                req = ServiceRequest_dictparse(req_unparsed)
+                if isinstance(req, ServiceRequest):
+                    if req.service and req.service in self._providers.keys():
+
+                        request_args = pickle.loads(req.args) if req.args else ()
+                        # add 'self' if providers[req.service] is a bound method.
+                        if self._providers[req.service].self:
+                            request_args = (self,) + request_args
+                        request_kwargs = pickle.loads(req.kwargs) if req.kwargs else {}
+
+                        resp = self._providers[req.service].func(*request_args, **request_kwargs)
+                        svc_skt.send(ServiceResponse(
+                            service=req.service,
+                            response=pickle.dumps(resp),
+                        ).serialize())
+
+                    else:
+                        raise UnknownServiceException("Unknown Service {0}".format(req.service))
+                else:  # should not happen : dictparse would fail before reaching here...
+                    raise UnknownRequestTypeException("Unknown Request Type {0}".format(type(req.request)))
+            except Exception:  # we transmit back all errors, and keep spinning...
+                exctype, excvalue, tb = sys.exc_info()
+                # trying to make a pickleable traceback
+                try:
+                    ftb = Traceback(tb)
+                except TypeError as exc:
+                    ftb = "Traceback manipulation error: {exc}. Verify that python-tblib is installed.".format(exc=exc)
+
+                # sending back that exception with traceback
+                svc_skt.send(ServiceResponse(
+                    service=req.service,
+                    exception=ServiceException(
+                        exc_type=pickle.dumps(exctype),
+                        exc_value=pickle.dumps(excvalue),
+                        traceback=pickle.dumps(ftb),
+                    )
+                ).serialize())
+
+        # triggering other updates
+        self._loop_target(*args, **kwargs)
+
     def shutdown(self, join=True, timeout=None):
         """
         Clean shutdown of the node.
@@ -368,32 +297,15 @@ class Node(object):
         exitcode = self._process.exitcode if self._process else None  # we return None if the process was never started
         return exitcode
 
-    def run(self, *args, **kwargs):
-        """
-        The Node main method, running in a child process (similar to Process.run() but also accepts args)
-        A children class can override this method, but it needs to call super().run(*args, **kwargs)
-        for the node to start properly and call update() as expected.
-        :param args: arguments to pass to update()
-        :param kwargs: keyword arguments to pass to update()
-        :return: last exitcode returned by update()
-        """
-        # TODO : make use of the arguments ? since run is now the target for Process...
-
-        exitstatus = None  # keeping the semantic of multiprocessing.Process : running process has None
-
-        if setproctitle and self.new_title:
-            setproctitle.setproctitle("{0}".format(self.name))
-
-        print('[{node}] Node started as [{pid} <= {address}]'.format(node=self.name, pid=self.ident, address=self._svc_address))
-
-
+    @contextlib.contextmanager
+    def node_ctx(self):
         zcontext = zmq.Context()  # check creating context in init ( compatibility with multiple processes )
         # Apparently not needed ? Ref : https://github.com/zeromq/pyzmq/issues/770
         zcontext.setsockopt(socket.SO_REUSEADDR, 1)  # required to make restart easy and avoid debugging traps...
         svc_socket = zcontext.socket(zmq.REP)  # Ref : http://api.zeromq.org/2-1:zmq-socket # TODO : ROUTER instead ?
 
         try:  # attempting binding socket
-            svc_socket.bind(self._svc_address,)
+            svc_socket.bind(self._svc_address, )
         except zmq.ZMQError as ze:
             if ze.errno == errno.ENOENT:  # No such file or directory
                 # TODO : handle all possible cases
@@ -414,104 +326,79 @@ class Node(object):
         except Exception as e:
             raise
 
-
         poller = zmq.Poller()
         poller.register(svc_socket, zmq.POLLIN)
 
         # Initializing all context managers
         with service_provider_cm(
-                    self.name, self._svc_address, self._providers
-                ), node_cm(self.name, self._svc_address), self.context_manager() as cm:
+                self.name, self._svc_address, self._providers
+        ), node_cm(self.name, self._svc_address):
+            yield poller, svc_socket
 
-            # Starting the clock
-            start = time.time()
+        # all context managers are cleanedup here
 
-            first_loop = True
-            # loop listening to connection
-            while not self.exit.is_set():
-
-                # signalling startup only the first time, just after having check for exit request.
-                # We need to guarantee at least ONE call to update.
-                if first_loop:
-                    self.started.set()
-
-                # blocking. messages are received ASAP. timeout only determine update/shutdown speed.
-                socks = dict(poller.poll(timeout=100))
-                if svc_socket in socks and socks[svc_socket] == zmq.POLLIN:
-                    req = None
-                    try:
-                        req_unparsed = svc_socket.recv()
-                        req = ServiceRequest_dictparse(req_unparsed)
-                        if isinstance(req, ServiceRequest):
-                            if req.service and req.service in self._providers.keys():
-
-                                request_args = pickle.loads(req.args) if req.args else ()
-                                # add 'self' if providers[req.service] is a bound method.
-                                if self._providers[req.service].self:
-                                    request_args = (self, ) + request_args
-                                request_kwargs = pickle.loads(req.kwargs) if req.kwargs else {}
-
-                                resp = self._providers[req.service].func(*request_args, **request_kwargs)
-                                svc_socket.send(ServiceResponse(
-                                    service=req.service,
-                                    response=pickle.dumps(resp),
-                                ).serialize())
-
-                            else:
-                                raise UnknownServiceException("Unknown Service {0}".format(req.service))
-                        else:  # should not happen : dictparse would fail before reaching here...
-                            raise UnknownRequestTypeException("Unknown Request Type {0}".format(type(req.request)))
-                    except Exception:  # we transmit back all errors, and keep spinning...
-                        exctype, excvalue, tb = sys.exc_info()
-                        # trying to make a pickleable traceback
-                        try:
-                            ftb = Traceback(tb)
-                        except TypeError as exc:
-                            ftb = "Traceback manipulation error: {exc}. Verify that python-tblib is installed.".format(exc=exc)
-
-                        # sending back that exception with traceback
-                        svc_socket.send(ServiceResponse(
-                            service=req.service,
-                            exception=ServiceException(
-                                exc_type=pickle.dumps(exctype),
-                                exc_value=pickle.dumps(excvalue),
-                                traceback=pickle.dumps(ftb),
-                            )
-                        ).serialize())
-
-                # time is ticking
-                # TODO : move this out of here. this class should require only generic interface to update method.
-                now = time.time()
-                timedelta = now - start
-                start = now
-
-                # replacing the original Process.run() call, passing arguments to our target
-                if self._target:
-                    # bwcompat
-                    kwargs['timedelta'] = timedelta
-
-                    # TODO : use return code to determine when/how we need to run this the next time...
-                    # Also we need to keep the exit status to be able to call external process as an update...
-
-                    logging.debug("[{self.name}] calling {self._target.__name__} with args {args} and kwargs {kwargs}...".format(**locals()))
-                    exitstatus = self._target(*args, **kwargs)
-
-                if first_loop:
-                    first_loop = False
-
-                if exitstatus is not None:
-                    break
-
-            if self.started.is_set() and exitstatus is None and self.exit.is_set():
-                # in the not so special case where we started, we didnt get exit code and we exited,
-                # this is expected as a normal result and we set an exitcode here of 0
-                # As 0 is the conventional success for unix process successful run
-                exitstatus = 0
-
-        logging.debug("[{self.name}] Node stopped.".format(**locals()))
-        return exitstatus  # returning last exit status from the update function
-
-        # all context managers are destroyed properly here
+    # def run(self, *args, **kwargs):
+    #     """
+    #     The Node main method, running in a child process (similar to Process.run() but also accepts args)
+    #     A children class can override this method, but it needs to call super().run(*args, **kwargs)
+    #     for the node to start properly and call update() as expected.
+    #     :param args: arguments to pass to update()
+    #     :param kwargs: keyword arguments to pass to update()
+    #     :return: last exitcode returned by update()
+    #     """
+    #     # TODO : make use of the arguments ? since run is now the target for Process...
+    #
+    #     exitstatus = None  # keeping the semantic of multiprocessing.Process : running process has None
+    #
+    #     print('[{node}] Node started as [{pid} <= {address}]'.format(node=self.name, pid=self.ident, address=self._svc_address))
+    #
+    #     with self.node_ctx() as (poller, svc_skt):
+    #
+    #         # Starting the clock
+    #         start = time.time()
+    #
+    #         first_loop = True
+    #         # loop listening to connection
+    #         while not self.exit.is_set():
+    #
+    #             # signalling startup only the first time, just after having check for exit request.
+    #             # We need to guarantee at least ONE call to update.
+    #             if first_loop:
+    #                 self.started.set()
+    #
+    #             # time is ticking
+    #             # TODO : move this out of here. this class should require only generic interface to update method.
+    #             now = time.time()
+    #             timedelta = now - start
+    #             start = now
+    #
+    #             # replacing the original Process.run() call, passing arguments to our target
+    #             if self._target:
+    #                 # bwcompat
+    #                 kwargs['timedelta'] = timedelta
+    #
+    #                 # TODO : use return code to determine when/how we need to run this the next time...
+    #                 # Also we need to keep the exit status to be able to call external process as an update...
+    #
+    #                 logging.debug("[{self.name}] calling {self._target.__name__} with args {args} and kwargs {kwargs}...".format(**locals()))
+    #                 exitstatus = self._target(*args, **kwargs)
+    #
+    #             if first_loop:
+    #                 first_loop = False
+    #
+    #             if exitstatus is not None:
+    #                 break
+    #
+    #         if self.started.is_set() and exitstatus is None and self.exit.is_set():
+    #             # in the not so special case where we started, we didnt get exit code and we exited,
+    #             # this is expected as a normal result and we set an exitcode here of 0
+    #             # As 0 is the conventional success for unix process successful run
+    #             exitstatus = 0
+    #
+    #     logging.debug("[{self.name}] Node stopped.".format(**locals()))
+    #     return exitstatus  # returning last exit status from the update function
+    #
+    #     # all context managers are destroyed properly here
 
 
 

--- a/pyzmp/tests/test_coprocess.py
+++ b/pyzmp/tests/test_coprocess.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+# To allow python to run these tests as main script
+import contextlib
+import functools
+import multiprocessing
+import sys
+import os
+import threading
+
+import types
+from random import randint
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+import time
+import pyzmp
+
+import pytest
+# http://pytest.org/latest/contents.html
+# https://github.com/ionelmc/pytest-benchmark
+
+# TODO : PYPY
+# http://pypy.org/
+
+# TODO : Test Node exception : correctly transmitted, process still keeps spinning...
+
+
+@pytest.mark.timeout(5)
+def test_process_termination():
+    """Checks that a process can be shutdown without being started and indicate that it never ran"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+    exitcode = n1.shutdown()  # shutdown should have no effect here (if not started, same as noop )
+    assert exitcode is None  # exitcode should be None (process didn't start and didn't stop so no exit code)
+    assert not n1.is_alive()
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_termination():
+    """Checks that a process can be started and shutdown and indicate that it ran successfully"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+    exitcode = n1.shutdown()
+    assert exitcode == 0  # default process should spin without issues
+    assert not n1.is_alive()
+
+
+@pytest.mark.timeout(5)
+def test_process_timeout_creation_termination():
+    """Checks that a process can be started with timeout and shutdown and indicate that it ran successfully"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+    svc_url = n1.start(1)
+    assert svc_url
+    assert n1.is_alive()
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+
+# @nose.SkipTest  # to help debugging ( FIXME : how to programmatically start only one test - maybe in fixture - ? )
+@pytest.mark.timeout(5)
+def test_process_double_creation_termination():
+    """Checks that a process can be started twice and shutdown and indicate that it ran successfully"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+    svc_url1 =n1.start()
+    assert n1.is_alive()
+    assert svc_url1
+    svc_url2 = n1.start()  # this shuts down properly and restart the process
+    assert n1.is_alive()
+    assert svc_url2
+
+    # the process is the same (same id) so we should get same url
+    assert svc_url1 == svc_url2
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+
+# @nose.SkipTest  # to help debugging ( FIXME : how to programmatically start only one test - maybe in fixture - ? )
+@pytest.mark.timeout(5)
+def test_process_timeout_double_creation_termination():
+    """Checks that a process can be started twice with timeout and shutdown and indicate that it ran successfully"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+    svc_url1 = n1.start(1)
+    assert n1.is_alive()
+    assert svc_url1
+
+    svc_url2 = n1.start(1)  # this shuts down and restart the process
+    assert n1.is_alive()
+    assert svc_url2
+
+    # the process is the same (same id) so we should get same url
+    assert svc_url1 == svc_url2
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_double_termination():
+    """Checks that a process can be started and shutdown twice and indicate that it ran successfully"""
+    n1 = pyzmp.CoProcess()
+    assert not n1.is_alive()
+
+    svc_url1 = n1.start()
+    assert n1.is_alive()
+    assert svc_url1
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+    exitcode = n1.shutdown()
+    assert exitcode == 0  # the exit code is still 0 since we didn't restart...
+    assert not n1.is_alive()
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_args():
+    """Checks that a process can be passed an argument using inheritance"""
+    ns = multiprocessing.Manager().Namespace()
+    ns.arg = 42
+
+    class TestArgProcess(pyzmp.CoProcess):
+        def task(self, *args, **kwargs):
+            ns.arg -= args[0]
+            return ns.arg
+
+    n1 = TestArgProcess(args=(ns.arg,))
+    assert not n1.is_alive()
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+
+    # starting and shutdown should at least guarantee ONE call of update function.
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+    assert ns.arg == 0
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_args_delegate():
+    """Checks that a process can be passed an argument using delegation"""
+    ns = multiprocessing.Manager().Namespace()
+    ns.arg = 42
+
+    def arguser(fortytwo, **kwargs):  # kwargs is there to accept extra arguments nicely (timedelta)
+        ns.arg -= fortytwo
+        return ns.arg
+
+    n1 = pyzmp.CoProcess(args=(ns.arg,), target=arguser)
+    assert not n1.is_alive()
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+    assert ns.arg == 0
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_kwargs():
+    """Checks that a process can be passed a keyword argument using inheritance"""
+    ns = multiprocessing.Manager().Namespace()
+    ns.kwarg = 42
+
+    class TestKWArgProcess(pyzmp.CoProcess):
+        def task(self, *args, **kwargs):
+            ns.kwarg -= kwargs.get('intval')
+            return ns.kwarg
+
+    n1 = TestKWArgProcess(kwargs={'intval': ns.kwarg, })
+    assert not n1.is_alive()
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+    assert ns.kwarg == 0
+
+
+@pytest.mark.timeout(5)
+def test_process_creation_kwargs_delegate():
+    """Checks that a process can be passed a keyword argument using delegation"""
+    ns = multiprocessing.Manager().Namespace()
+    ns.kwarg = 42
+
+    def kwarguser(intval, **kwargs):  # kwargs is there to accept extra arguments nicely (timedelta)
+        ns.kwarg -= intval
+        return ns.kwarg
+
+    n1 = pyzmp.CoProcess(kwargs={'intval': ns.kwarg, }, target=kwarguser)
+    assert not n1.is_alive()
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+    assert ns.kwarg == 0
+
+
+# @nose.SkipTest  # to help debugging ( FIXME : how to programmatically start only one test - maybe in fixture - ? )
+@pytest.mark.timeout(5)
+def test_process_as_context_manager():
+    """Checks that a process can be used as a context manager"""
+    with pyzmp.CoProcess() as n1:  # this will __init__ and __enter__
+        assert n1.is_alive()
+    assert not n1.is_alive()
+
+
+# @nose.SkipTest  # to help debugging ( FIXME : how to programmatically start only one test - maybe in fixture - ? )
+@pytest.mark.timeout(5)
+def test_process_running_as_context_manager():
+    """Checks that an already running process can be used as a context manager"""
+    n1 = pyzmp.CoProcess()
+    n1.start()
+    with n1:  # hooking to an already started process
+        # This might restart the process (might be bad but ideally should not matter.)
+        assert n1.is_alive()
+    assert not n1.is_alive()
+
+
+
+@pytest.mark.timeout(300)
+def test_context_before_started():
+    """Checks that a coprocess initializes its context before starting """
+
+    mgr = multiprocessing.Manager()
+    # creating namespace proxy (see https://docs.python.org/3/library/multiprocessing.html#proxy-objects)
+    ns = mgr.Namespace()
+
+    mypid = os.getpid()
+
+    # We can use the context to setup the value in the namespace
+    @contextlib.contextmanager
+    def ctxtuser():
+        # to make sure we are in another process
+        assert os.getpid() != mypid
+        # ns is referenced in this closure and proxy has been passed to child process
+        ns.kwarg = 42
+        yield ns
+        ns.kwarg = None  # to make sure we exit before shutdown returns
+
+    def kwarguser(ns, intval, *args, **kwargs):  # kwargs is there to accept extra arguments nicely (timedelta)
+        ns.kwarg -= intval
+        ns.call = ns.call +1 if hasattr(ns,'call') else 1  # first call is 1
+        return ns.kwarg
+
+    n1 = pyzmp.CoProcess(kwargs={'intval': 42, }, target=kwarguser, context_manager=ctxtuser)
+    assert not n1.is_alive()
+
+    # here the context has NOT already been entered
+    assert not hasattr(ns, 'kwarg')
+
+    svc_url = n1.start()
+    assert n1.is_alive()
+    assert svc_url
+
+    # here the context HAS BEEN entered
+    assert hasattr(ns, 'kwarg')
+
+    # MAYBE update has NOT already been called
+    # Note we want to keep indeterminism here, as linearizability of events should only be enforced
+    # via context manager with the usual method/procedure call API.
+    # other events could potentially be completely asynchronous (might depend on OS / process interface)
+    assert ns.kwarg in [42, 0]
+
+    exitcode = n1.shutdown()
+    assert exitcode == 0
+    assert not n1.is_alive()
+
+    # update HAS been called once (or more), and context has been exited
+    assert ns.call >= 1
+    assert ns.kwarg is None
+
+
+
+### TODO : more testing in case of crash in process, exception, signal, etc.
+
+# Just in case we run this directly
+if __name__ == '__main__':
+    import pytest
+    pytest.main([
+        '-s', __file__,
+])

--- a/pyzmp/tests/test_coprocess.py
+++ b/pyzmp/tests/test_coprocess.py
@@ -242,7 +242,7 @@ def test_process_running_as_context_manager():
 
 
 
-@pytest.mark.timeout(300)
+@pytest.mark.timeout(5)
 def test_context_before_started():
     """Checks that a coprocess initializes its context before starting """
 
@@ -254,11 +254,11 @@ def test_context_before_started():
 
     # We can use the context to setup the value in the namespace
     @contextlib.contextmanager
-    def ctxtuser():
+    def ctxtuser(intval, *args, **kwargs):
         # to make sure we are in another process
         assert os.getpid() != mypid
         # ns is referenced in this closure and proxy has been passed to child process
-        ns.kwarg = 42
+        ns.kwarg = intval
         yield ns
         ns.kwarg = None  # to make sure we exit before shutdown returns
 

--- a/pyzmp/tests/test_node.py
+++ b/pyzmp/tests/test_node.py
@@ -159,7 +159,7 @@ def test_node_creation_args_delegate():
         ns.arg -= fortytwo
         return ns.arg
 
-    n1 = pyzmp.Node(args=(ns.arg,), target=arguser)
+    n1 = pyzmp.Node(args=(ns.arg,), loop_target=arguser)
     assert not n1.is_alive()
     svc_url = n1.start()
     assert n1.is_alive()
@@ -206,7 +206,7 @@ def test_node_creation_kwargs_delegate():
         ns.kwarg -= intval
         return ns.kwarg
 
-    n1 = pyzmp.Node(kwargs={'intval': ns.kwarg, }, target=kwarguser)
+    n1 = pyzmp.Node(kwargs={'intval': ns.kwarg, }, loop_target=kwarguser)
     assert not n1.is_alive()
     svc_url = n1.start()
     assert n1.is_alive()
@@ -238,39 +238,6 @@ def test_node_running_as_context_manager():
         # This might restart the node (might be bad but ideally should not matter.)
         assert n1.is_alive()
     assert not n1.is_alive()
-
-
-@pytest.mark.timeout(5)
-def test_update_before_started():
-    """Checks that a node can be passed a keyword argument using delegation"""
-    ns = multiprocessing.Manager().Namespace()
-    ns.kwarg = 42
-
-    def kwarguser(intval, **kwargs):  # kwargs is there to accept extra arguments nicely (timedelta)
-        ns.kwarg -= intval
-        return ns.kwarg
-
-    n1 = pyzmp.Node(kwargs={'intval': ns.kwarg, }, target=kwarguser)
-    assert not n1.is_alive()
-
-    # here the update has NOT already been called once
-    assert ns.kwarg == 42
-
-    svc_url = n1.start()
-    assert n1.is_alive()
-    assert svc_url
-
-    # here the update has already been called once
-    assert ns.kwarg == 0
-
-    exitcode = n1.shutdown()
-    assert exitcode == 0
-    assert not n1.is_alive()
-
-    assert ns.kwarg == 0
-
-
-
 
 
 def test_update_rate():
@@ -337,9 +304,9 @@ def test_update_rate():
 
 
 
-### TODO : more testing in case of crash in process, exception, signal, etc.
-
+# Just in case we run this directly
 if __name__ == '__main__':
-
-    import nose
-    nose.runmodule()
+    import pytest
+    pytest.main([
+        '-s', __file__,
+])


### PR DESCRIPTION
In a way that process can be converted to asyncio (later), and eventually merge API...
Currently doing the strict minimum.

Goal : 
- Process supports the whole start / stop subprocess duties, along with a "one time" task/command/code to execute, and a signal interface.
- Node supports the whole eventloop style from asyncio, and a network interface.

*Later* we will need to investigate how a one time remote command could also be just a coroutines, and how to merge multiple concepts in one...